### PR TITLE
Package refinements

### DIFF
--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 42a3fb4b98d1047d09235df08060e7f1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 62af2df078a724348bc04772ff944623
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime.meta
+++ b/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9964bf215ee974acd8630d6bbe1812d8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Nethereum.Unity.WalletConnect.asmdef
+++ b/Runtime/Nethereum.Unity.WalletConnect.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Nethereum.Unity.WalletConnect",
+    "rootNamespace": "Nethereum.WalletConnect",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Runtime/Nethereum.Unity.WalletConnect.asmdef.meta
+++ b/Runtime/Nethereum.Unity.WalletConnect.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bb350e476ce664d2dad3a8b7e3afe99e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Nethereum.WalletConnect.dll.meta
+++ b/Runtime/Nethereum.WalletConnect.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 7bec38a2d0e2f48afa1cf4ca9dbb1363
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Third Party Notices.md.meta
+++ b/Third Party Notices.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 51ccc567753cd4e2a86b4264843b1813
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
   {
 	  "name": "com.nethereum.unity.walletconnect",
-	  "displayName": "Nethereum",
+	  "displayName": "Nethereum.WalletConnect",
 	  "version": "4.19.1",
 	  "unity": "2018.1",
 	  "description": "Nethereum walletconnect runtime integration dlls, please check Nethereum releases for more information, https://github.com/Nethereum/Nethereum/releases, example can be found at https://github.com/Nethereum/Unity3dSampleTemplate",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	  "name": "com.nethereum.unity.walletconnect",
 	  "displayName": "Nethereum.WalletConnect",
 	  "version": "4.19.1",
-	  "unity": "2018.1",
+	  "unity": "2021.3",
 	  "description": "Nethereum walletconnect runtime integration dlls, please check Nethereum releases for more information, https://github.com/Nethereum/Nethereum/releases, example can be found at https://github.com/Nethereum/Unity3dSampleTemplate",
 	  "changelogUrl": "https://github.com/Nethereum/Nethereum/releases",
 	  "author": {

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aa4592cfbd795420582736e8c86fec59
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Added meta files (https://github.com/Nethereum/Nethereum.Unity.WalletConnect/commit/8972d888d38cbeb5f25033cc326f0b73b2d9d409), without them package doesn't work.
* Set minimal supported Unity Version (https://github.com/Nethereum/Nethereum.Unity.WalletConnect/commit/e0222f6b6d2342ae32ab59fcb530805a91c413a1) to 2021.3 as it's the lowest version supported by WalletConnectUnity.
* Added assembly definition (https://github.com/Nethereum/Nethereum.Unity.WalletConnect/commit/133d92939b7959964f6edd7b7035d3adbc9954ef). Without asmdef package may not be referenced by scripts when installed directly from git or via OpenUPM.
* Changed displayName to Nethereum.WalletConnect (https://github.com/Nethereum/Nethereum.Unity.WalletConnect/commit/cd74dea1e086326ee1b980f1ce28768b8d0dd151). Otherwise this package can be confused with `Nethereum.Unity` which has the same name. 
<img src=https://github.com/Nethereum/Nethereum.Unity.WalletConnect/assets/15127974/e638e927-d7d5-4fb8-a163-5d55c6f1a488 width=400/>